### PR TITLE
Enable Japanese Input in Node Components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/src/Node.js
+++ b/src/Node.js
@@ -1,6 +1,6 @@
 // Node.js
 
-import { memo, useCallback, useState, useEffect } from 'react';
+import { memo, useCallback, useState, useEffect, useRef } from 'react';
 import NodeLayout from './NodeLayout';
 import { useGraphManager } from './GraphManagerContext';
 
@@ -68,10 +68,24 @@ function Node({ data, isConnectable, id, prevs }) {
     setNodes,
   } = useGraphManager();
   const [nodeData, setNodeData] = useState(data);
+  const changeBuffer = useRef({});
 
   useEffect(() => {
     setNodeData(data);
   }, [data]);
+
+  const handleChange = useCallback((event) => {
+    const name = event.target.name;
+    const value = event.target.value;
+    const isComposingEvent = event.nativeEvent.isComposing;
+
+    if (isComposingEvent) {
+      changeBuffer.current = { [name]: value };
+    } else {
+      updateNodeData((prevData) => ({ ...prevData, ...changeBuffer.current }));
+      changeBuffer.current = {};
+    }
+  }, [id, setNodes]);
 
   const updateNodeData = (updateFn) => {
     setNodes((nds) => {
@@ -87,22 +101,6 @@ function Node({ data, isConnectable, id, prevs }) {
     });
   };
 
-  const onChangeName = useCallback((evt) => {
-    updateNodeData((prevData) => ({ ...prevData, name: evt.target.value }));
-  }, [id, setNodes]);
-
-  const onChangeDescription = useCallback((evt) => {
-    updateNodeData((prevData) => ({ ...prevData, description: evt.target.value }));
-  }, [id, setNodes]);
-
-  const onChangeType = useCallback((evt) => {
-    updateNodeData((prevData) => ({ ...prevData, type: evt.target.value }));
-  }, [id, setNodes]);
-
-  const onChangeTool = useCallback((tool) => {
-    updateNodeData((prevData) => ({ ...prevData, tool }));
-  }, [id, setNodes]);
-
   const onResize = useCallback((width, height) => {
     updateNodeData((prevData) => ({ ...prevData, width, height }));
   }, [id, setNodes]);
@@ -111,10 +109,10 @@ function Node({ data, isConnectable, id, prevs }) {
     <NodeLayout
       data={nodeData}
       isConnectable={isConnectable}
-      onChangeName={onChangeName}
-      onChangeDescription={onChangeDescription}
-      onChangeType={onChangeType}
-      onChangeTool={onChangeTool}
+      onChangeName={handleChange}
+      onChangeDescription={handleChange}
+      onChangeType={handleChange}
+      onChangeTool={handleChange}
       onResize={onResize}
       prevs={prevs}
     />

--- a/src/Node.js
+++ b/src/Node.js
@@ -68,7 +68,6 @@ function Node({ data, isConnectable, id, prevs }) {
     setNodes,
   } = useGraphManager();
   const [nodeData, setNodeData] = useState(data);
-  const changeBuffer = useRef({});
 
   useEffect(() => {
     setNodeData(data);
@@ -79,11 +78,11 @@ function Node({ data, isConnectable, id, prevs }) {
     const value = event.target.value;
     const isComposingEvent = event.nativeEvent.isComposing;
 
-    if (isComposingEvent) {
-      changeBuffer.current = { [name]: value };
-    } else {
-      updateNodeData((prevData) => ({ ...prevData, ...changeBuffer.current }));
-      changeBuffer.current = {};
+    if (!isComposingEvent) {
+      updateNodeData((prevData) => {
+        const updatedData = Object.assign({}, prevData, { [name]: value });
+        return updatedData;
+      });
     }
   }, [id, setNodes]);
 
@@ -109,10 +108,7 @@ function Node({ data, isConnectable, id, prevs }) {
     <NodeLayout
       data={nodeData}
       isConnectable={isConnectable}
-      onChangeName={handleChange}
-      onChangeDescription={handleChange}
-      onChangeType={handleChange}
-      onChangeTool={handleChange}
+      handleChange={handleChange}
       onResize={onResize}
       prevs={prevs}
     />

--- a/src/NodeLayout.js
+++ b/src/NodeLayout.js
@@ -11,13 +11,7 @@ const handleStyle = {
   background: '#555',
 };
 
-function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, onChangeType, onResize, onChangeTool }) {
-  const handleTypeChange = useCallback((evt) => {
-    const newType = evt.target.value;
-    onChangeType(evt);
-    // Update the node data type
-    data.type = newType;
-  }, [onChangeType, data]);
+function NodeLayout({ data, isConnectable, handleChange, onResize, onCompositionStart, onCompositionEnd }) {
 
   const handleResize = useCallback((evt, { width, height }) => {
     onResize(width, height);
@@ -42,7 +36,7 @@ function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, on
         minHeight={200} 
         onResize={handleResize}
       >
-        <ResizeIcon />
+      <ResizeIcon />
       </NodeResizeControl>
       <Handle
         type="target"
@@ -77,8 +71,7 @@ function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, on
           <select
             id="type"
             name="type"
-            value={data.type}
-            onChange={handleTypeChange}
+            onChange={handleChange}
             className="nodrag"
             style={{ width: 'calc(100% - 20px)' }}
           >
@@ -96,8 +89,7 @@ function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, on
                 <input
                   id="text"
                   name="text"
-                  value={data.name}
-                  onChange={onChangeName}
+                  onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)' }}
                 />
@@ -109,8 +101,7 @@ function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, on
                 <input
                   id="tool"
                   name="tool"
-                  value={data.tool}
-                  onChange={(evt) => onChangeTool(evt.target.value)}
+                  onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)' }}
                 />
@@ -122,8 +113,7 @@ function NodeLayout({ data, isConnectable, onChangeName, onChangeDescription, on
                 <textarea
                   id="description"
                   name="description"
-                  value={data.description}
-                  onChange={onChangeDescription}
+                  onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)', height: 'calc(100% - 30px)', resize: 'none' }}
                 />

--- a/src/NodeLayout.js
+++ b/src/NodeLayout.js
@@ -11,7 +11,7 @@ const handleStyle = {
   background: '#555',
 };
 
-function NodeLayout({ data, isConnectable, handleChange, onResize, onCompositionStart, onCompositionEnd }) {
+function NodeLayout({ data, isConnectable, handleChange, onResize }) {
 
   const handleResize = useCallback((evt, { width, height }) => {
     onResize(width, height);
@@ -71,6 +71,7 @@ function NodeLayout({ data, isConnectable, handleChange, onResize, onComposition
           <select
             id="type"
             name="type"
+            defaultValue={data.type}
             onChange={handleChange}
             className="nodrag"
             style={{ width: 'calc(100% - 20px)' }}
@@ -87,8 +88,9 @@ function NodeLayout({ data, isConnectable, handleChange, onResize, onComposition
               <div>
                 <label htmlFor="text" style={{ display: 'block', fontSize: '12px' }}>Name:</label>
                 <input
-                  id="text"
-                  name="text"
+                  id="name"
+                  name="name"
+                  defaultValue={data.name}
                   onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)' }}
@@ -101,6 +103,7 @@ function NodeLayout({ data, isConnectable, handleChange, onResize, onComposition
                 <input
                   id="tool"
                   name="tool"
+                  defaultValue={data.tool}
                   onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)' }}
@@ -113,6 +116,7 @@ function NodeLayout({ data, isConnectable, handleChange, onResize, onComposition
                 <textarea
                   id="description"
                   name="description"
+                  defaultValue={data.description}
                   onChange={handleChange}
                   className="nodrag"
                   style={{ width: 'calc(100% - 20px)', height: 'calc(100% - 30px)', resize: 'none' }}


### PR DESCRIPTION
## Description:  

This update introduces support for Japanese input (IME composition events) in node components by:
- Refactoring input handling to properly process composition events using `isComposing` checks.
- Replacing individual `onChange` handlers (`onChangeName`, `onChangeType`, etc.) with a unified `handleChange` function for better maintainability and reduced duplication.
- Updating `NodeLayout` to work with the new unified handler and composition events.

Additional changes include minor formatting improvements and new editor settings to avoid automatic formatting conflicts.

## Reference

- To support inputting Japanese katakana or kanji, it was necessary to account for composition events.
- https://github.com/facebook/react/issues/3926